### PR TITLE
fix: generate all referenced external files

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
     "release": "release-it"
   },
   "type": "module",
-  "version": "0.3.0-alpha.3"
+  "version": "0.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
     "release": "release-it"
   },
   "type": "module",
-  "version": "0.2.3"
+  "version": "0.3.0-alpha.1"
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
     "release": "release-it"
   },
   "type": "module",
-  "version": "0.3.0-alpha.2"
+  "version": "0.3.0-alpha.3"
 }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
     "release": "release-it"
   },
   "type": "module",
-  "version": "0.3.0-alpha.1"
+  "version": "0.3.0-alpha.2"
 }

--- a/src/generateTs.ts
+++ b/src/generateTs.ts
@@ -191,8 +191,11 @@ function generateMessage(
   const oneOfs: DescOneof[] = [];
   const openApiV2Schema = getOpenapiMessageOption(message);
   const requiredFields = openApiV2Schema?.jsonSchema?.required;
+  const messageName = [message.parent?.name, message.name]
+  .filter(Boolean)
+  .join("_");
   f.print(f.jsDoc(message));
-  f.print(`export type ${message.name} = {`);
+  f.print(`export type ${messageName} = {`);
   for (const member of message.members) {
     switch (member.kind) {
       case "oneof":

--- a/src/generateTs.ts
+++ b/src/generateTs.ts
@@ -20,6 +20,7 @@ import {
   getGoogleapisFieldBehaviorOption,
   getGoogleapisHttpMethodOption,
   getGoogleapisResourceOption,
+  getDescName,
   getOpenapiMessageOption,
   isExternalDependency,
   isShapeImport,
@@ -64,9 +65,7 @@ function generateEnum(
   f: GeneratedFile,
   enumeration: DescEnum
 ) {
-  const enumName = [enumeration.parent?.name, enumeration.name]
-    .filter(Boolean)
-    .join("_");
+  const enumName = getDescName(enumeration);
   f.print(f.jsDoc(enumeration));
   f.print(`export enum ${enumName} {`);
   for (const value of enumeration.values) {
@@ -191,9 +190,7 @@ function generateMessage(
   const oneOfs: DescOneof[] = [];
   const openApiV2Schema = getOpenapiMessageOption(message);
   const requiredFields = openApiV2Schema?.jsonSchema?.required;
-  const messageName = [message.parent?.name, message.name]
-  .filter(Boolean)
-  .join("_");
+  const messageName = getDescName(message);
   f.print(f.jsDoc(message));
   f.print(`export type ${messageName} = {`);
   for (const member of message.members) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -121,6 +121,19 @@ export const pathParametersToLocal = (path: string) => {
   });
 };
 
+/**
+ * Returns a proper TypeScript name for a potentially nested message or enum.
+ */
+export const getDescName = (d: DescEnum | DescMessage) => {
+  let name = d.name;
+  let p;
+  while ((p = d.parent)) {
+    name = `${p.name}_${name}`;
+    d = p;
+  }
+  return name;
+};
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Coppied from starts
 // https://github.com/bufbuild/protobuf-es/blob/ef8766d2aab4764a35bfed78960fc62ec2f0dfac/packages/protoc-gen-es/src/util.ts#L32-L141

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  type DescEnum,
   type DescExtension,
   type DescField,
   type DescMessage,
@@ -23,6 +24,7 @@ import {
   type ResourceDescriptor,
   resource,
 } from "../options/gen/google/api/resource_pb";
+import type { PluginSchema } from "./generateTs";
 
 export const getOpenapiMessageOption = (
   message: DescMessage
@@ -46,7 +48,30 @@ export const getGoogleapisResourceOption = (
   return getOption(message, resource);
 };
 
-export const isWKTMessage = (message: DescMessage) => {
+export const isExternalDependency = (
+  schema: PluginSchema,
+  message: DescEnum | DescMessage
+) => {
+  const internalDependency = schema.files.find(
+    (file) => file.name === message.file.name
+  );
+  return !internalDependency;
+};
+
+// type from @protobuf but unexported
+export type ShapeImport = {
+  readonly kind: "es_shape_ref";
+  desc: DescEnum | DescMessage;
+};
+
+export const isShapeImport = (
+  p: Exclude<Printable, Printable[]>
+): p is ShapeImport =>
+  Boolean(
+    p && typeof p === `object` && `kind` in p && p.kind === `es_shape_ref`
+  );
+
+export const isWKTMessage = (message: DescEnum | DescMessage) => {
   return message.file.proto.package.startsWith("google.protobuf");
 };
 

--- a/tests/generateTs.message.test.ts
+++ b/tests/generateTs.message.test.ts
@@ -337,3 +337,36 @@ export enum NestedEnum_State {
 }`
   );
 });
+
+test(`should generate external dependencies`, async () => {
+  const inputFileName = `external_dependencies.proto`;
+  const req = await getCodeGeneratorRequest(`target=ts`, [
+    {
+      name: inputFileName,
+      content: `syntax = "proto3";
+
+import "google/rpc/status.proto";
+
+message MessageExternalDep {
+  string foo = 1;
+  google.rpc.Status status = 2;
+};`,
+    },
+  ]);
+  const resp = getResponse(req);
+  const outputFile = findResponseForInputFile(resp, inputFileName);
+  assertTypeScript(
+    outputFile.content!,
+    `
+import type { Status } from "./google/rpc/status_pb"
+
+export type MessageExternalDep = {
+  foo?: string;
+  status?: Status;
+}`
+  );
+  const generatedDependency = findResponseForInputFile(
+    resp,
+    `google/rpc/status.proto`
+  );
+});

--- a/tests/generateTs.message.test.ts
+++ b/tests/generateTs.message.test.ts
@@ -370,3 +370,32 @@ export type MessageExternalDep = {
     `google/rpc/status.proto`
   );
 });
+
+test.only(`should handle nested messages`, async () => {
+  const inputFileName = `nested_message.proto`;
+  const req = await getCodeGeneratorRequest(`target=ts`, [
+    {
+      name: inputFileName,
+      content: `syntax = "proto3";
+message NestedMessage {
+  message Nested {
+    string foo = 1;
+  }
+  repeated Nested bar = 1;
+};`,
+    },
+  ]);
+  const resp = getResponse(req);
+  const outputFile = findResponseForInputFile(resp, inputFileName);
+  assertTypeScript(
+    outputFile.content!,
+    `
+export type NestedMessage {
+  bar?: NestedMessage_Nested[];
+};
+
+export type NestedMessage_Nested = {
+  foo?: string;
+};`
+  );
+});

--- a/tools/go/buf
+++ b/tools/go/buf
@@ -4,4 +4,4 @@
 # This will make generation and build reproducible and independent on the local
 # environment.
 
-go run github.com/bufbuild/buf/cmd/buf@v1.10.0 "$@"
+go run github.com/bufbuild/buf/cmd/buf@v1.47.2 "$@"


### PR DESCRIPTION
This change allows generation of proto files which refers to other definitions - typically a google types. All the external dependencies are generated into TypeScript so TypeScript imports are not broken

Also, this fixes a bug where nested messages or enums were not properly named