### PR TITLE
fix: minor issues

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -202,7 +202,7 @@ export const appendQueryParameter = (
 ) => {
   if (isScalarType(value)) {
     searchParams.append(key, String(value));
-  } else {
+  } else if (typeof value === `object`) {
     console.warn(
       `Property "${key}" in request message is not send in request body, and cannot be send in a query-string parameters because it contains a value of type _object_. Property ${key}" will be skipped.`
     );

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -12,6 +12,7 @@ import {
   replacePathParameters,
   toBigIntString,
   toBytesString,
+  unset,
 } from "../src/runtime";
 
 describe(`replacePathParameters`, () => {
@@ -21,8 +22,12 @@ describe(`replacePathParameters`, () => {
       name: "projects/a/documents/b",
       message_id: "XYZ",
     };
-    const replaced = replacePathParameters(path, parameters);
+    const [replaced, modifiedParameters] = replacePathParameters(
+      path,
+      parameters
+    );
     expect(replaced).toBe("/v1/projects/a/documents/b/XYZ");
+    expect(modifiedParameters).toEqual({});
   });
 });
 
@@ -188,5 +193,22 @@ describe("pathPatternToParseRegexp", () => {
     expect(reReady).toBe(
       `projects\\/(?<project>[^/]+)\\/documents\\/(?<document>[^/]+)\\/results\\/(?<result>[^/]+)`
     );
+  });
+});
+
+describe("unset", () => {
+  it(`should remove a key from an object`, () => {
+    const obj = { a: 1, b: 2 };
+    const modified = unset(obj, "a");
+    expect(modified).toEqual({ b: 2 });
+  });
+  it(`should use a structural clone to avoid mutation`, () => {
+    const obj = { a: 1, b: 2 };
+    expect(obj).toEqual({ a: 1, b: 2 });
+  });
+  it(`should handle deeply nested values`, () => {
+    const obj = { a: 1, b: 2, c: { cc: { ccc: 3, cd: 4 } } };
+    const modified = unset(obj, "c.cc.cd");
+    expect(modified).toEqual({ a: 1, b: 2, c: { cc: { ccc: 3 } } } as any);
   });
 });


### PR DESCRIPTION
This PR fixes two problems

- false positive warning, that property going to be serialized as query-string is of type object and cannot be stringified - this reported also an _undefined_ values,
- input messages passed into the RPC class were sometimes mutated - the function created a clone of the input message, but that clone was shallow and if there was a change of the data in some deeper levels, then the mutation leaked into the input message/object which might cause surprising bugs - the logic of mutating the input message was changed so the method that works with the data is immutable and uses structural sharing to be memory efficient.