### PR TITLE
feat: introduce "empty_as_null" option

### DIFF
--- a/src/generateTs.ts
+++ b/src/generateTs.ts
@@ -88,7 +88,7 @@ function generateType(
 ): { type: Printable; nullable?: boolean } {
   if (Array.isArray(typing)) {
     // in case of an array, there is _usually_ the type in first position and there can be an array `[]` notation at the
-    // second position, so we are just intereseted in the first position. Let's see how far this will get us.
+    // second position, so we are just interested in the first position. Let's see how far this will get us.
     const resolved = generateType(
       typing[0],
       required,
@@ -110,7 +110,7 @@ function generateType(
       case `Duration`:
       case `Timestamp`:
         // the Duration and Timestamp are serialized to string in gRPC-gateway, but we also need them to be nullable
-        // otherwiser it is impossible to unset them.
+        // otherwise it is impossible to unset them.
         return {
           type: `string`,
           nullable:
@@ -149,8 +149,9 @@ function generateField(
     googleapisFieldBehaviorOptions,
     runtimeFile
   );
+  const extendNullType = Boolean(nullable || (schema.options.emptyAsNull && !required && field.fieldKind !== `scalar`))
   f.print`${field.localName}${required ? "" : "?"}: ${type}${
-    !nullable ? "" : " | null"
+    extendNullType ? " | null" : ""
   };`;
   const typeNonArray: Exclude<Printable, Printable[]> = Array.isArray(type)
     ? type[0]

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,7 +8,10 @@ import { name, version } from "../package.json" assert { type: "json" };
  */
 const OPT_GENERATE_NAME_PARSER = "generate_name_parser";
 
+const OPT_EMPTY_AS_NULL = "empty_as_null";
+
 export type PluginOptions = {
+  emptyAsNull: boolean;
   generateNameParser: boolean;
 };
 
@@ -19,8 +22,16 @@ function parseOptions(
   }[]
 ): PluginOptions {
   let generateNameParser = false;
+  let emptyAsNull = false;
   for (const { key, value } of options) {
     switch (key) {
+      case OPT_EMPTY_AS_NULL: {
+        if (!["true", "false"].includes(value)) {
+          throw "please provide true or false";
+        }
+        emptyAsNull = value === "true";
+        break;
+      }
       case OPT_GENERATE_NAME_PARSER: {
         if (!["true", "false"].includes(value)) {
           throw "please provide true or false";
@@ -32,7 +43,7 @@ function parseOptions(
         throw new Error();
     }
   }
-  return { generateNameParser };
+  return { emptyAsNull, generateNameParser };
 }
 
 export const createPlugin = () =>

--- a/tests/generateTs.message.test.ts
+++ b/tests/generateTs.message.test.ts
@@ -437,3 +437,38 @@ export enum MultipleNested_Nested_State {
 }`
   );
 });
+
+test(`should type the non-required non-scalar fields as possible 'null' when empty_as_null option is set`, async () => {
+  const inputFileName = `empty_as_null.proto`;
+  const req = await getCodeGeneratorRequest(`target=ts,empty_as_null=true`, [
+    {
+      name: inputFileName,
+      content: `syntax = "proto3";
+
+message MessageA {
+  string foo = 1;
+  MessageB bar = 2;
+  map<string, string> baz = 3;
+};
+
+message MessageB {
+  string bar = 1;
+}`,
+    },
+  ]);
+  const resp = getResponse(req);
+  const outputFile = findResponseForInputFile(resp, inputFileName);
+  assertTypeScript(
+    outputFile.content!,
+    `
+export type MessageA = {
+  foo?: string;
+  bar?: MessageB | null;
+  baz?: { [key: string]: string } | null;
+}
+
+export type MessageB = {
+  bar?: string;
+}`
+  );
+});


### PR DESCRIPTION
Adds a new `empty_as_null` boolean flag. When turned on, all non-scalar fields that are not required (can be empty) have a type signature extended with `null`. Previously, such types allowed either type or `undefined`, but that causes a problem with implicit `update_mask` generation. 